### PR TITLE
Changes to add krun to the kontain release

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,23 @@ You can run Kontain payload wrapped in a native Docker container.... in this cas
 
 #### Kontain OCI runtime (krun)
 
-**** KRUN is not in the bundle yet, skip this section ****
-
 Or you can use Kontain `krun` runtime from docker/podman or directly. `krun` is installed together with KM and other components.
 `krun` is forked from Redhat's `crun` runtime github project, and can be invoked as `krun`.
 One of many introductions to runtimes can be found here:
 https://medium.com/@avijitsarkar123/docker-and-oci-runtimes-a9c23a5646d6
+
+* krun package requirements
+
+krun needs some packages which may not be on your system, install them as follows if they are not already present on your system:
+
+For fedora:
+
+sudo dnf install yajl-devel.x86_64 libseccomp.x86_64 libcap.x86_64
+
+For ubuntu:
+
+sudo apt-get update
+sudo apt-get install -y libyajl2 libseccomp2 libcap2
 
 Configuring `krun`:
 
@@ -111,10 +122,10 @@ Edit /etc/docker/daemon.json using sudo to run your editor and add the following
     "default-runtime": "runc",
     "runtimes": {
       "krun": {
-        "path": "/opt/kontain/bin/krun",
+        "path": "/opt/kontain/bin/krun"
       },
       "crun": {
-        "path": "/opt/kontain/bin/crun",
+        "path": "/opt/kontain/bin/crun"
       }
     }
   }

--- a/kontain-install.sh
+++ b/kontain-install.sh
@@ -11,6 +11,7 @@ set -e ; [ "$TRACE" ] && set -x
 readonly TAG=${1:-0.10-beta}
 readonly PREFIX="/opt/kontain"
 readonly URL="https://github.com/kontainapp/km-releases/releases/download/${TAG}/kontain.tar.gz"
+readonly NEEDED_PACKAGES="yajl libseccomp libcap glibc"
 
 function check_args {
    # "check-arg: Noop for now"
@@ -24,6 +25,17 @@ function warning {
 function error {
    echo "*** Error:  $*"
    exit 1
+}
+
+pkgs_missing=0
+function check_packages {
+    echo "Checking that packages $NEEDED_PACKAGES are present"
+    for i in $NEEDED_PACKAGES ; do
+        if ! rpm -qa | grep $i -q ; then
+            pkgs_missing=1
+            warning "Package $i is required and is not installed."
+        fi
+    done
 }
 
 validate=0
@@ -71,9 +83,13 @@ function get_bundle {
       echo Install either KVM or KKM Module and then validate installation by running
       echo $PREFIX/bin/km $PREFIX/tests/hello_test.km Hello World
    fi
+   if [ $pkgs_missing -ne 0 ]; then
+      echo "Some packages need to be installed to use all functionality"
+   fi
 }
 
 # main
 check_args
 check_prereqs
+check_packages
 get_bundle

--- a/kontain-install.sh
+++ b/kontain-install.sh
@@ -46,7 +46,7 @@ function install_packages {
     elif [ "$NAME" == "Fedora" ] ; then
         sudo dnf install yajl-devel.x86_64 libseccomp.x86_64 libcap.x86_64
     else
-        echo "Unsupported linux: $NAME, packages libyajl, libseccomp, libcap may need to be installed"
+        echo "Unsupported linux: $NAME, packages libyajl, libseccomp, libcap may need to be installed for krun to work"
     fi
 }
 

--- a/kontain-install.sh
+++ b/kontain-install.sh
@@ -11,7 +11,6 @@ set -e ; [ "$TRACE" ] && set -x
 readonly TAG=${1:-0.10-beta}
 readonly PREFIX="/opt/kontain"
 readonly URL="https://github.com/kontainapp/km-releases/releases/download/${TAG}/kontain.tar.gz"
-readonly NEEDED_PACKAGES="yajl libseccomp libcap glibc"
 
 function check_args {
    # "check-arg: Noop for now"
@@ -36,6 +35,19 @@ function check_packages {
             warning "Package $i is required and is not installed."
         fi
     done
+}
+
+function install_packages {
+    source /etc/os-release
+    echo "Installing needed packages for $NAME"
+    if [ "$NAME" == "Ubuntu" ]; then
+        sudo apt-get update
+        sudo apt-get install -y libyajl2 libseccomp2 libcap2
+    elif [ "$NAME" == "Fedora" ] ; then
+        sudo dnf install yajl-devel.x86_64 libseccomp.x86_64 libcap.x86_64
+    else
+        echo "Unsupported linux: $NAME, packages libyajl, libseccomp, libcap may need to be installed"
+    fi
 }
 
 validate=0
@@ -91,5 +103,5 @@ function get_bundle {
 # main
 check_args
 check_prereqs
-check_packages
+install_packages
 get_bundle


### PR DESCRIPTION
Update getting started doc to describe how to use krun.
Change the install script to verify that packages krun depends upon are installed.